### PR TITLE
Improvement idea: Get port from .env

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 const server = require('./server');
 
-server.listen(3333 || process.env.PORT);
+server.listen(process.env.PORT || 3333);


### PR DESCRIPTION
In this context, wouldn't it be better to try using what comes from environments and then use the default port if there is no environments?